### PR TITLE
Écriture inclusive et anglicismes

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,12 @@
+# Software Carpentry Checklists Translation
+
+This repository contains translations (for the moment only in French) for the checklists needed when organizing a [Software Carpentry](http://software-carpentry.org/) workshop. See [this issue](https://github.com/swcarpentry/website/issues/839) for more general discussion on translating the Software Carpentry website.
+
+These are the original checklists:
+- [Accessibility Checklist](https://github.com/swcarpentry/website/blob/gh-pages/pages/checklists_accessibility.html)
+- [Admin Checklist](https://github.com/swcarpentry/website/blob/gh-pages/pages/checklists_admin.html)
+- [Helper Checklist](https://github.com/swcarpentry/website/blob/gh-pages/pages/checklists_helper.html)
+- [Host Checklist](https://github.com/swcarpentry/website/blob/gh-pages/pages/checklists_host.html)
+- [Instructor Checklist](https://github.com/swcarpentry/website/blob/gh-pages/pages/checklists_instructor.html)
+- [Lead Instructor Checklist](https://github.com/swcarpentry/website/blob/gh-pages/pages/checklists_lead.html)
+- [Learner Checklist](https://github.com/swcarpentry/website/blob/gh-pages/pages/checklists_learner.html)

--- a/fr-organisation.md
+++ b/fr-organisation.md
@@ -144,7 +144,7 @@ Le⋅a formateur⋅rice principal⋅e est aussi responsable de la préparation d
 - Se coordonner avec l'hôte⋅sse pour envoyer au⋅à la coordinateur⋅rice de Data Carpentry les informations sur les participant⋅e⋅s à l'atelier.
 - Compléter les mêmes tâches d'après atelier que les formateur⋅rice⋅s
 
-### Les Responsabilités de tous les formateurs/formatrices
+### Les Responsabilités de tous les formateur⋅rice⋅s
 
 Chaque formateur⋅rice est responsable de la préparation de l'enseignement de leur(s) section(s). N'oubliez pas que le contenu de nos leçons évolue sans cesse, et que même si vous avez enseigné dans le passé, vous devrez vérifier le contenu des leçons pour tout changement éventuel.
 

--- a/fr-organisation.md
+++ b/fr-organisation.md
@@ -10,8 +10,7 @@
 
 * Nous mettrons en place un site internet, et un système d'inscription (si
   besoin) pour votre atelier. C'est à l'organisateur⋅rice, vous, de décider si une
-  participation financière est demandée aux participant⋅e⋅s. Souvent, nous avons
-  observé que demander une participation de 20€ diminue considérablement le
+  participation financière est demandée aux participant⋅e⋅s. Une participation de 20€ diminue considérablement le
   nombre de personnes qui s'inscrivent mais ne se présentent pas le jour de
   l'atelier. Étant donné que ces ateliers sont le plus souvent pleins et qu'il y
   a une liste d'attente, il est préférable de proposer ces places aux personnes
@@ -28,14 +27,14 @@
 
 * L'hôte⋅sse et les formateur⋅rice⋅s organiseront ensemble les
   déplacements avant l'atelier. Les formateur⋅rice⋅s ne connaîtront pas les lieux,
-  donc l'aide que vous pourrez leur apporter avec la réservation de l'hôtel et
-  le transport depuis l'aéroport ou la gare sera appréciée.
+  et apprécieront donc l'aide que vous pourrez leur apporter pour la réservation de leur hôtel et
+  le transport depuis l'aéroport.
 
 ### Frais pour organiser un atelier
 
 Le coût de l'organisation d'un atelier comprend non seulement les frais administratifs d'organisation de l'atelier, mais aussi les frais de déplacements pour deux formateur⋅rice⋅s.
 
-* **Frais administratifs de l'atelier**: US$2500 -- ceci est le prix pour les
+* **Frais administratifs de l'atelier**: US$2500 -- il s'agit du prix pour les
   organisations à but non lucratif (universités, organisations gouvernementales,
   etc.). Pour les frais administratifs pour les organisations à but lucratif,
   merci de [nous contacter](mailto:tkteal@datacarpentry.org) &ast;.
@@ -51,7 +50,7 @@ Le coût de l'organisation d'un atelier comprend non seulement les frais adminis
   modalités de remboursement sont à établir au moment de la planification de
   l'atelier.
 
-&ast; 50% des frais administratifs pour les ateliers organisés par des organisations à but lucratif servent à supporter les ateliers dans des zones qui ont des difficultés financières.
+&ast; 50% des frais administratifs pour les ateliers organisés par des organisations à but lucratif servent à financer les ateliers dans des zones qui ont des difficultés financières.
 
 ### Les Responsabilités de l'hôte⋅sse
 
@@ -63,10 +62,10 @@ Pour les ateliers organisés par Data Carpentry, les hôte⋅sse⋅s sont respon
 - Choisir avec [le⋅a coordinateur⋅rice de Data Carpentry](admin@datacarpentry.org) la date et le lieu pour l'atelier
 - Choisir et réserver la salle pour l'atelier
 - S'assurer que la salle choisie est accessible à tou⋅te⋅s les participant⋅e⋅s:
-  * demander sur le formulaire d'inscription si les participant⋅e⋅s ont des demandes particulières (par exemple, interprète de la langue des signes, **handout** imprimés en gros caractères, salle d'allaitement)
+  * demander sur le formulaire d'inscription si les participant⋅e⋅s ont des demandes particulières (par exemple, interprète de la langue des signes, **polycopié** imprimés en gros caractères, salle d'allaitement)
   * demander aux formateur⋅rice⋅s et aux assistant⋅e⋅s s'ils ont des demandes particulières
   * envoyer les liens pour le contenu de l'atelier à l'avance pour que les participant⋅e⋅s puissent les adapter si besoin.
-	* le bâtiment et la salle pour l'atelier sont accessibles à ceux qui ne peuvent pas utiliser les escaliers.
+	* le bâtiment et la salle pour l'atelier sont accessibles à ceux qui ne peuvent pas utiliser les escaliers
 	* l'ascenseur est disponible pour l'intégralité de la durée de l'atelier
 	* il y a des toilettes accessibles aux personnes à mobilité réduite à proximité de la salle de l'atelier
 	* la salle peut accueillir les chiens guides.
@@ -85,32 +84,32 @@ Pour les ateliers organisés par Data Carpentry, les hôte⋅sse⋅s sont respon
   * rallonges et multi-prises
   * mot de passe et nom d'utilisateurs pour accéder au wifi si besoin
   * post-its de deux couleurs
-  * badges (autocollants) pour les noms, et crayons
+  * badges (autocollants) pour les noms et sytlos
   * liste des participant⋅e⋅s à l'atelier pour l'appel
   * formulaires d'autorisation à la publication et l'utilisation de photos (si besoin)
-- Arranger café, thé, collation (les participant⋅e⋅s apprécient)
+- S'occuper du café, du thé ou d'une collation (les participant⋅e⋅s apprécient)
 - Envoyer les informations sur la participation à l'atelier et tout retour au⋅à la coordinateur⋅rice de Data Carpentry (admin@datacarpentry.org)
 
-### Les Responsabilités du coordinateur/de la coordinatrice de Data Carpentry
+### Les Responsabilités du coordinat⋅rice de Data Carpentry
 
 Pour les ateliers organisés par Data Carpentry, notre coordinateur⋅rice se chargera de :
 
-- Aider l'hôte⋅sse dans la sélection de la date et du lieu pour leur atelier
-- Recruter et choisir des formateur⋅rice⋅s qui répondent aux contraintes de l'hôte
+- Aider l'hôte⋅sse dans le choix de la date et du lieu pour leur atelier
+- Recruter et choisir des formateur⋅rice⋅s qui correspondent aux contraintes de l'hôte
 - Aider l'hôte⋅sse à recruter des assistant⋅e⋅s locaux (si demandé)
 - Mettre en place les enquêtes d'avant et d'après atelier qui seront distribués par les formateur⋅rice⋅s aux participant⋅e⋅s
 - Communiquer avec les formateur⋅rice⋅s pour s'assurer que la plannification et l'enseignement se déroulent dans de bonnes conditions
 - Installer et admnistrer la page d'inscription pour l'atelier
-- Enregister les informations pertinentes à chaque atelier dans la base de données interne à Data Carpentry
-- Aider à annoncer l'atelier sur le compte Twitter de Data Carpentry and sur les listes de discussions (si demandé)
+- Enregister les informations pertinentes pour chaque atelier dans la base de données interne à Data Carpentry
+- Aider à diffuser l'annonce de l'atelier sur le compte Twitter de Data Carpentry et sur les listes de discussions (si demandé)
 - Contacter les formateur⋅rice⋅s pour participer aux discussions d'après atelier
-- Servir de point de contact pour l'hôte(sse) et les formateur⋅rice⋅s pour répondre aux questions et fournir des ressources supplémentaires si besoin.
+- Servir de point de contact pour l'hôte⋅sse et les formateur⋅rice⋅s pour répondre aux questions et fournir des ressources supplémentaires si besoin.
 
-Le⋅a coordinateur⋅rice des ateliers de Data Carpentry se charge de s'assurer que les ateliers soient une expérience enrichissante et de haute qualité pour répondre aux exigences de votre institution. Si vous avez des questions sur le rôle du⋅de la coordinateur⋅rice des ateliers, ou si vous souhaitez mettre en place des arrangements particuliers pour votre atelier, n'hésitez pas à contacter le⋅a coordinateur⋅rice à admin@datacarpentry.org
+Le⋅a coordinateur⋅rice des ateliers de Data Carpentry doit s'assurer que les ateliers soient une expérience enrichissante et de haute qualité pour répondre aux exigences de votre institution. Si vous avez des questions sur le rôle du⋅de la coordinateur⋅rice des ateliers, ou si vous souhaitez mettre en place des dispositions particulières pour votre atelier, n'hésitez pas à contacter le⋅a coordinateur⋅rice à admin@datacarpentry.org
 
 ### Les Responsabilités du formateur principal/de la formatrice principale
 
-Le⋅a formateur⋅rice principal⋅e est responsable de la coordination avec les co-formateur⋅rice⋅s et l'hôte⋅sse du contenu de l'atelier. Ils sont aussi en charge de mettre en place le site internet pour l'atelier et pour la distribution des enquêtes auprès des participant⋅e⋅s. Toutes ces tâches peuvent être déléguées, mais c'est au⋅à la formateur⋅rice principal⋅e de s'assurer qu'elles soient accomplies. Si vous vous êtes vus assigné le rôle de formateur⋅rice principal⋅e mais que vous n'êtes pas confortable dans cette position ou que vous vous rendez compte que vous n'avez pas le temps de remplir les tâches demandées, prenez contact avec le⋅a coordinateur⋅rice de Data Carpentry le plus rapidement possible (admin@datacarpentry.org).
+Le⋅a formateur⋅rice principal⋅e est responsable de la coordination avec les co-formateur⋅rice⋅s et l'hôte⋅sse du contenu de l'atelier. Il⋅elle⋅s s'occupent de mettre en place le site internet pour l'atelier et pour la distribution des enquêtes auprès des participant⋅e⋅s. Toutes ces tâches peuvent être déléguées, mais c'est au⋅à la formateur⋅rice principal⋅e de s'assurer qu'elles soient accomplies. Si vous vous êtes vu⋅e⋅s assigné⋅e le rôle de formateur⋅rice principal⋅e mais que vous n'êtes pas confortable dans cette position ou que vous vous rendez compte que vous n'avez pas le temps de remplir les tâches demandées, prenez contact avec le⋅a coordinateur⋅rice de Data Carpentry le plus rapidement possible (admin@datacarpentry.org).
 
 Le⋅a formateur⋅rice principal⋅e est aussi responsable de la préparation du contenu de l'atelier, voir les responsabilités du⋅de la formateur⋅rice ci-dessous.
 
@@ -125,9 +124,9 @@ Le⋅a formateur⋅rice principal⋅e est aussi responsable de la préparation d
   pour votre atelier
 - Aider l'hôte⋅sse à recruter des assistant⋅e⋅s pour l'atelier (au moins 1 assistant⋅e
   pour 12 participant⋅e⋅s)
-- S'assurer en coordination avec l'hôte⋅sse que l'atelier est accessible
+- S'assurer en coordination avec l'hôte⋅sse que l'atelier est accessible à tou⋅te⋅s
 - Se préparer à enseigner le contenu pédagogique de l'atelier
-- Envoyer un email aux participant⋅e⋅s pour leur rappeler du lieu et des heures de
+- Envoyer un email aux participant⋅e⋅s pour leur rappeler le lieu et les heures de
   l'atelier, ainsi que des logiciels et autres pré-requis qu'ils doivent
   installer avant de venir à l'atelier. Cet email doit aussi contenir le lien de
   l'enquête d'avant-atelier.
@@ -136,18 +135,18 @@ Le⋅a formateur⋅rice principal⋅e est aussi responsable de la préparation d
 
 #### Pendant l'atelier
 
-- S'assurer que les noms et adresses électroniques des participant⋅e⋅s sont collectés pendant
+- S'assurer que les noms et adresses électroniques des participant⋅e⋅s soient collectées pendant
   l'atelier
 - Envoyer le lien, et s'assurer de la complétion de l'enquête d'après atelier.
 
 #### Après l'atelier
 
-- Coordonner avec l'hôte⋅sse pour envoyer au⋅à la coordinateur⋅rice de Data Carpentry les informations sur les participant⋅e⋅s à l'atelier.
-- Compléter les mêmes taches d'après atelier que les formateur⋅rice⋅s
+- Se coordonner avec l'hôte⋅sse pour envoyer au⋅à la coordinateur⋅rice de Data Carpentry les informations sur les participant⋅e⋅s à l'atelier.
+- Compléter les mêmes tâches d'après atelier que les formateur⋅rice⋅s
 
 ### Les Responsabilités de tous les formateurs/formatrices
 
-Chaque formateur⋅rice est responsable de la préparation de l'enseignement de leur(s) section(s). N'oubliez pas que le contenu de nos leçon évolue sans cesse, et que même si vous avez enseigné dans le passé, vous devrez vérifier le contenu pour tout changement éventuel.
+Chaque formateur⋅rice est responsable de la préparation de l'enseignement de leur(s) section(s). N'oubliez pas que le contenu de nos leçons évolue sans cesse, et que même si vous avez enseigné dans le passé, vous devrez vérifier le contenu des leçons pour tout changement éventuel.
 
 #### Avant l'atelier
 
@@ -159,7 +158,7 @@ Chaque formateur⋅rice est responsable de la préparation de l'enseignement de 
 - Tester que les instructions pour l'installation des logiciels et données pour
   l'atelier fonctionnent correctement
 - Lire les leçons que vous allez enseigner en détail
-- S'il y a un guide d'instruction pour les leçons que vous allez enseigner, le
+- S'il y a un guide d'enseignement pour les leçons que vous allez enseigner, le
   lire en détail
 - Faire une répétition de l'ensemble de la leçon
 - Lire le guide de dépannage
@@ -185,7 +184,7 @@ Chaque formateur⋅rice est responsable de la préparation de l'enseignement de 
 
 ## Modèles de courriels
 
-Ces modèles de courriels sont seulement fournis à titre indicatif. Nous espérons qu'ils vous seront utiles dans la planification de votre atelier. N'hésitez pas à les modifier si nécessaire. Le texte [entre parenthèses carrées] devra être remplacé par les informations propres à votre atelier.
+Ces modèles de courriels sont seulement fournis à titre indicatif. Nous espérons qu'ils vous seront utiles dans la planification de votre atelier. N'hésitez pas à les modifier si nécessaire. Le texte [entre crochets] devra être remplacé par les informations propres à votre atelier.
 
 ### Pour les ateliers organisés en autonomie seulement
 
@@ -195,7 +194,7 @@ Bonjour [nom],
 
 J'organise un atelier Data Carpentry en [mois prévu]. Data Carpentry est une organisation à but non-lucratif qui aide les chercheur⋅se⋅s à apprendre comment organiser et analyser leurs données de manière efficace et reproductible. Ces ateliers enseignent des compétences qui sont immédiatement utiles aux chercheur⋅se⋅s, en utilisant des jeux de données spécifiques à leur domaine d'expertise, afin qu'ils puissent appliquer rapidement ce qu'ils apprennent à leur propres données. Je suis très enthousiaste à l'idée d'utiliser le contenu des ateliers Data Carpentry ici pour aider nos [doctorant⋅e⋅s, équipes, personnels, enseignant⋅e⋅s, chercheur⋅se⋅s... ] à être plus efficaces dans leur recherche.
 
-J'ai suivi la formation pédagogique pour devenir formateur Data Carpentry, et je suis certifié⋅e pour enseigner leurs ateliers. Afin d'organiser un de leurs atelier, je vais avoir besoin d'un (préféremment deux) co-formateur⋅rice⋅s pour m'aider à enseigner le contenu de l'atelier. Ces ateliers durent deux jours et les formateur⋅rice⋅s généralement alternent après chaque demi-journée. Je pense couvrir [les sujets de votre atelier], et j'espérai que tu puisses enseigner le module sur [sujet]. Data Carpentry fournit des leçons qui sont prêtes à être enseignées, donc nous n'aurons pas à tout faire de zéro. Si tu es intéressé⋅e, tu peux voir le contenu sur [sujet] ici [lien vers la leçon], et le reste du contenu de leurs ateliers ici: http://datacarpentry.org/lessons
+J'ai suivi la formation pédagogique pour devenir formateur Data Carpentry, et je suis certifié⋅e pour enseigner leurs ateliers. Afin d'organiser un de leurs atelier, je vais avoir besoin d'un (préféremment deux) co-formateur⋅rice⋅s pour m'aider à enseigner le contenu de l'atelier. Ces ateliers durent deux jours et les formateur⋅rice⋅s généralement changent après chaque demi-journée. Je pense couvrir [les sujets de votre atelier], et j'espérai que tu puisses enseigner le module sur [sujet]. Data Carpentry fournit des leçons qui sont prêtes à être enseignées, donc nous n'aurons pas à partir de zéro. Si tu es intéressé⋅e, tu peux voir le contenu sur [sujet] ici [lien vers la leçon], et le reste du contenu de leurs ateliers ici: http://datacarpentry.org/lessons
 
 Si tu es intéressé⋅e pour être un⋅e co-formateur⋅rice, dis-le moi et nous pouvons nous voir pour nous organiser. Si tu connais d'autres personnes qui seraient intéressées pour nous aider, n'hésite pas à les contacter.
 
@@ -213,14 +212,14 @@ Pendant l'atelier, je vais avoir besoin d'assistant⋅e⋅s pour aider au cas o�
 
 [Nom de l'institution/organisation] atelier Data Carpentry [dates, lieu]
 
-Le [date], [nom de l'institution/organisation] accueille un atelier Data Carpentry pour [audience cible, sujet]. Les ateliers Data Carpentry enseignent les compétences nécessaires pour débuter avec l'organisation et l'analyse des données dans tous les domaines de recherche. Leur mission est de fournir aux chercheurs/chercheuses une formation accueillante, de haute qualité qui couvre tout le cycle de vie de la recherche basée les données. Les leçons sont spécifiques à des domaines de recherche, et cet atelier se focalise sur [sujet]. Le contenu de l'atelier contiendra :
+Le [date], [nom de l'institution/organisation] accueille un atelier Data Carpentry pour [audience cible, sujet]. Les ateliers Data Carpentry enseignent les compétences nécessaires pour débuter avec l'organisation et l'analyse des données dans tous les domaines de recherche. Leur mission est de fournir aux chercheur⋅se⋅s une formation accueillante, de haute qualité qui couvre tout le cycle de vie de la recherche basée sur les données. Les leçons sont spécifiques à des domaines de recherche, et cet atelier se focalise sur [sujet]. Le contenu de l'atelier contiendra :
 
 - [leçon]
 - [leçon]
 - [leçon]
 - [leçon]
 
-Ces ateliers sont destinées à ceux qui ont peu ou pas d'expérience en programmation, et les formateur⋅rice⋅s font l'une de leur priorités de créer un environement accueillant pour donner aux chercheur⋅se⋅s la confiance dont ils ont besoin pour qu'ils puissent utiliser leurs données pour faire des découvertes. Les participant⋅e⋅s qui ont déjà un peu d'expérience profiteront de cet atelier, car le but n'est pas seulement d'enseigner comment faire des analyses, mais aussi comment organiser ses analyses pour automatiser le processus et le rendre reproductible.
+Ces ateliers sont destinées à ceux⋅elles qui ont peu ou pas d'expérience en programmation, et les formateur⋅rice⋅s font l'une de leur priorités de créer un environement accueillant pour donner aux chercheur⋅se⋅s la confiance dont ils ont besoin pour qu'ils puissent utiliser leurs données pour faire des découvertes. Les participant⋅e⋅s qui ont déjà un peu d'expérience profiteront de cet atelier, car le but n'est pas seulement d'enseigner comment faire des analyses, mais aussi comment organiser ses analyses pour automatiser le processus et le rendre reproductible.
 
 Le nombre de places pour cet atelier est limité, et il est probable que l'atelier soit complet rapidement. [Ajouter une phrase pour préciser si l'atelier est gratuit ou s'il y a des frais d'inscriptions à payer]. Pour vous inscrire, cliquer ici [lien vers la page d'inscription], et pour plus d'informations, vous pouvez visiter la page de l'atelier ici [lien vers le site internet de l'atelier].
 
@@ -255,10 +254,10 @@ N'hésitez pas à nous contacter si vous avez des questions, sinon à [jour de l
 
 Bonjour,
 
-Merci d'avoir participé à notre atelier Data Carpentry. Nous espérons que vous avez appris beaucoup et que vous vous êtes amusé⋅e⋅s.
+Merci d'avoir participé⋅e à notre atelier Data Carpentry. Nous espérons que vous avez appris beaucoup et que vous vous êtes amusé⋅e⋅s.
 
 Si vous ne l'avez pas déjà fait, n'oubliez pas de remplir notre enquête d'après-atelier [lien]. Vos réponses sont essentielles pour nous permettre d'améliorer en permanence nos ateliers pour nos futurs participants.
 
 Si vous avez des commentaires sur l'atelier, ou que vous souhaitez vous impliquer dans la communauté de Data Carpentry, n'hésitez pas à nous contacter (admin@datacarpentry.org). Vous pouvez aussi joindre notre liste de discussion (http://lists.software-carpentry.org/listinfo/discuss), nous suivre sur Twitter (@DataCarpentry), ou vous impliquer dans le développement de nos leçons sur GitHub (https://github.com/datacarpentry).
 
-Nous espérons que nous aurons l'occasion de vous revoir dans votre poursuite de l'amélioration de vos compétences en dans l'analyse de données.
+Nous espérons que nous aurons l'occasion de vous revoir dans votre poursuite de l'amélioration de vos compétences en l'analyse de données.

--- a/fr-organisation.md
+++ b/fr-organisation.md
@@ -5,35 +5,35 @@
 
 * Pour demander un atelier, remplissez ce [formulaire de demande (en anglais)](https://amy.software-carpentry.org/workshops/dc/request/). Nous vous demandons de nous préciser la période pendant laquelle vous souhaitez organiser l'atelier, et des informations sur le public visé, afin que nous puissions vous informer du programme d'atelier qui sera le plus adapté pour celui-ci.
 
-* Nous recruterons des formateurs et formatrices volontaires pour votre atelier, et nous vous contacterons pour fixer une date et choisir le contenu de l'atelier qui répondra
+* Nous recruterons des formateur⋅rice⋅s volontaires pour votre atelier, et nous vous contacterons pour fixer une date et choisir le contenu de l'atelier qui répondra
   le mieux à vos besoins.
 
 * Nous mettrons en place un site internet, et un système d'inscription (si
-  besoin) pour votre atelier. C'est à l'organisateur/organisatrice, vous, de décider si une
-  participation financière est demandée aux participants. Souvent, nous avons
+  besoin) pour votre atelier. C'est à l'organisateur⋅rice, vous, de décider si une
+  participation financière est demandée aux participant⋅e⋅s. Souvent, nous avons
   observé que demander une participation de 20€ diminue considérablement le
   nombre de personnes qui s'inscrivent mais ne se présentent pas le jour de
   l'atelier. Étant donné que ces ateliers sont le plus souvent pleins et qu'il y
   a une liste d'attente, il est préférable de proposer ces places aux personnes
   sur liste d'attente plutôt que d'avoir des sièges vides.
 
-* Le formateur principal ou la formatrice principale sera votre point de contact pour coordonner les
-  détails de l'organisation et pour communiquer avec les participant(e)s à
-  l'atelier. Le formateur principal ou la formatrice principale se chargera aussi de communiquer avec le
+* Le⋅a formateur⋅rice principal⋅e sera votre point de contact pour coordonner les
+  détails de l'organisation et pour communiquer avec les participant⋅e⋅s à
+  l'atelier. Le⋅a formateur⋅rice principal⋅e se chargera aussi de communiquer avec le
   personnel de Data Carpentry au besoin.
 
-* L'hôte ou l'hôtesse (l'organisateur ou organisatrice de l'atelier, vous) doit se charger de l'organisation sur
+* L'hôte⋅sse (l'organisateur⋅rice de l'atelier, vous) doit se charger de l'organisation sur
   place : réservation de la salle, s'assurer du nombre suffisant de prises
   électriques, mise à disposition de café, etc.
 
-* L'hôte(sse) et les formateurs/formatrices organiseront ensemble les
-  déplacements avant l'atelier. Les formateurs/formatrices ne connaîtront pas les lieux,
+* L'hôte⋅sse et les formateur⋅rice⋅s organiseront ensemble les
+  déplacements avant l'atelier. Les formateur⋅rice⋅s ne connaîtront pas les lieux,
   donc l'aide que vous pourrez leur apporter avec la réservation de l'hôtel et
   le transport depuis l'aéroport ou la gare sera appréciée.
 
 ### Frais pour organiser un atelier
 
-Le coût de l'organisation d'un atelier comprend non seulement les frais administratifs d'organisation de l'atelier, mais aussi les frais de déplacements pour deux formateurs/formatrices.
+Le coût de l'organisation d'un atelier comprend non seulement les frais administratifs d'organisation de l'atelier, mais aussi les frais de déplacements pour deux formateur⋅rice⋅s.
 
 * **Frais administratifs de l'atelier**: US$2500 -- ceci est le prix pour les
   organisations à but non lucratif (universités, organisations gouvernementales,
@@ -44,41 +44,41 @@ Le coût de l'organisation d'un atelier comprend non seulement les frais adminis
   par cas.
 
 * **Frais de déplacements pour les formateurs**: ~ US$2000. Tous nos
-  formateurs/formatrices sont des volontaires, mais l'hôte(sse) s'engage à couvrir la totalité
-  de leurs frais de déplacement. Nous essayons de recruter des formateurs/formatrices
+  formateur⋅rice⋅s sont des volontaires, mais l'hôte⋅sse s'engage à couvrir la totalité
+  de leurs frais de déplacement. Nous essayons de recruter des formateur⋅rice⋅s
   proches, mais nous suggérons que vous budgétisez environ $2000 pour les frais
-  de déplacement, les repas, et l'hébergement des formateurs. Les détails des
+  de déplacement, les repas, et l'hébergement des formateur⋅rice⋅s. Les détails des
   modalités de remboursement sont à établir au moment de la planification de
   l'atelier.
 
 &ast; 50% des frais administratifs pour les ateliers organisés par des organisations à but lucratif servent à supporter les ateliers dans des zones qui ont des difficultés financières.
 
-### Les Responsabilités de l'hôte(sse)
+### Les Responsabilités de l'hôte⋅sse
 
-Pour les ateliers organisés par Data Carpentry, les hôte(sse)s sont responsables de toute la logistique locale, alors que le coordinateur/la coordinatrice de Data Carpentry se charge du reste (voir paragraphe ci-dessous). Si votre atelier est organisé en autonomie, l'hôte(sse) est en charge de toute l'organisation (voir section "Ateliers organisés en autonomie").
+Pour les ateliers organisés par Data Carpentry, les hôte⋅sse⋅s sont responsables de toute la logistique locale, alors que le⋅a coordinateur⋅rice de Data Carpentry se charge du reste (voir paragraphe ci-dessous). Si votre atelier est organisé en autonomie, l'hôte⋅sse est en charge de toute l'organisation (voir section "Ateliers organisés en autonomie").
 
 - Choisir le [programme](http://www.datacarpentry.org/workshops/) qui sera le
-  plus approprié pour vos participant(e)s
+  plus approprié pour vos participant⋅e⋅s
 - Remplir le [formulaire de demande d'atelier](https://amy.software-carpentry.org/workshops/dc/request/)
-- Choisir avec le [coordinateur/la coordinatrice de Data Carpentry](admin@datacarpentry.org) la date et le lieu pour l'atelier
+- Choisir avec [le⋅a coordinateur⋅rice de Data Carpentry](admin@datacarpentry.org) la date et le lieu pour l'atelier
 - Choisir et réserver la salle pour l'atelier
-- S'assurer que la salle choisie est accessible à tous les participant(e)s:
-  * demander sur le formulaire d'inscription si les participant(e)s ont des demandes particulières (par exemple, interprète de la langue des signes, **handout** imprimés en gros caractères, salle d'allaitement)
-  * demander aux formateurs/formatrices et aux assistant(e)s s'ils ont des demandes particulières
-  * envoyer les liens pour le contenu de l'atelier à l'avance pour que les participant(e)s puissent les adapter si besoin.
+- S'assurer que la salle choisie est accessible à tou⋅te⋅s les participant⋅e⋅s:
+  * demander sur le formulaire d'inscription si les participant⋅e⋅s ont des demandes particulières (par exemple, interprète de la langue des signes, **handout** imprimés en gros caractères, salle d'allaitement)
+  * demander aux formateur⋅rice⋅s et aux assistant⋅e⋅s s'ils ont des demandes particulières
+  * envoyer les liens pour le contenu de l'atelier à l'avance pour que les participant⋅e⋅s puissent les adapter si besoin.
 	* le bâtiment et la salle pour l'atelier sont accessibles à ceux qui ne peuvent pas utiliser les escaliers.
 	* l'ascenseur est disponible pour l'intégralité de la durée de l'atelier
 	* il y a des toilettes accessibles aux personnes à mobilité réduite à proximité de la salle de l'atelier
 	* la salle peut accueillir les chiens guides.
-	* un microphone est disponible pour le formateur
+	* un microphone est disponible pour le⋅a formateur⋅rice
 	* l'écran du projecteur est suffisamment grand pour être facile à lire.
-	* Si des participants, les formateurs/formatrices, ou les assistant(e)s indiquent à l'avance des besoins particuliers, l'hôte est en charge de s'assurer que tout est en place pour le jour de l'atelier. L'institution hôte a peut être un service d'aide et d'accompagnement aux personnes handicapées qui puisse vous aider.
-- Recruter des assistant(e)s pour l'atelier (au moins un assistant pour 12
+	* Si des participants, les formateur⋅rice⋅s, ou les assistant⋅e⋅s indiquent à l'avance des besoins particuliers, l'hôte⋅sse est en charge de s'assurer que tout est en place pour le jour de l'atelier. L'institution hôte⋅sse a peut être un service d'aide et d'accompagnement aux personnes handicapées qui puisse vous aider.
+- Recruter des assistant⋅e⋅s pour l'atelier (au moins un⋅e assistant⋅e pour 12
   participants).
 - Annoncer l'atelier
-- Payer les frais administratifs pour l'organisation de l'atelier et les frais des formateurs.
-- S'assurer que les formateurs/formatrices sachent comment demander le remboursement de leurs frais
-- Demander les numéros de téléphone des formateurs/formatrices et des assistant(e)s en cas de changements de dernière minute
+- Payer les frais administratifs pour l'organisation de l'atelier et les frais des formateur⋅rice⋅s.
+- S'assurer que les formateur⋅rice⋅s sachent comment demander le remboursement de leurs frais
+- Demander les numéros de téléphone des formateur⋅rice⋅s et des assistant⋅e⋅s en cas de changements de dernière minute
 - Obtenir tout le matériel nécessaire
   * un projecteur
   * les adaptateurs nécessaires
@@ -86,75 +86,75 @@ Pour les ateliers organisés par Data Carpentry, les hôte(sse)s sont responsabl
   * mot de passe et nom d'utilisateurs pour accéder au wifi si besoin
   * post-its de deux couleurs
   * badges (autocollants) pour les noms, et crayons
-  * liste des participants à l'atelier pour l'appel
+  * liste des participant⋅e⋅s à l'atelier pour l'appel
   * formulaires d'autorisation à la publication et l'utilisation de photos (si besoin)
-- Arranger café, thé, collation (les participants apprécient)
-- Envoyer les informations sur la participation à l'atelier et tout retour au coordinateur de Data Carpentry (admin@datacarpentry.org)
+- Arranger café, thé, collation (les participant⋅e⋅s apprécient)
+- Envoyer les informations sur la participation à l'atelier et tout retour au⋅à la coordinateur⋅rice de Data Carpentry (admin@datacarpentry.org)
 
 ### Les Responsabilités du coordinateur/de la coordinatrice de Data Carpentry
 
-Pour les ateliers organisés par Data Carpentry, notre coordinateur/coordinatrice se chargera de :
+Pour les ateliers organisés par Data Carpentry, notre coordinateur⋅rice se chargera de :
 
-- Aider l'hôte(sse) dans la sélection de la date et du lieu pour leur atelier
-- Recruter et choisir des formateurs/formatrices qui répondent aux contraintes de l'hôte
-- Aider l'hôte(sse) à recruter des assistant(e)s locaux (si demandé)
-- Mettre en place les enquêtes d'avant et d'après atelier qui seront distribués par les formateurs/formatrices aux participant(e)s
-- Communiquer avec les formateurs pour s'assurer que la plannification et l'enseignement se déroulent dans de bonnes conditions
+- Aider l'hôte⋅sse dans la sélection de la date et du lieu pour leur atelier
+- Recruter et choisir des formateur⋅rice⋅s qui répondent aux contraintes de l'hôte
+- Aider l'hôte⋅sse à recruter des assistant⋅e⋅s locaux (si demandé)
+- Mettre en place les enquêtes d'avant et d'après atelier qui seront distribués par les formateur⋅rice⋅s aux participant⋅e⋅s
+- Communiquer avec les formateur⋅rice⋅s pour s'assurer que la plannification et l'enseignement se déroulent dans de bonnes conditions
 - Installer et admnistrer la page d'inscription pour l'atelier
 - Enregister les informations pertinentes à chaque atelier dans la base de données interne à Data Carpentry
 - Aider à annoncer l'atelier sur le compte Twitter de Data Carpentry and sur les listes de discussions (si demandé)
-- Contacter les formateurs pour participer aux discussions d'après atelier
-- Servir de point de contact pour l'hôte(sse) et les formateurs/formatrices pour répondre aux questions et fournir des ressources supplémentaires si besoin.
+- Contacter les formateur⋅rice⋅s pour participer aux discussions d'après atelier
+- Servir de point de contact pour l'hôte(sse) et les formateur⋅rice⋅s pour répondre aux questions et fournir des ressources supplémentaires si besoin.
 
-Le coordinateur ou la coordinatrice des ateliers de Data Carpentry se charge de s'assurer que les ateliers soient une expérience enrichissante et de haute qualité pour répondre aux exigences de votre institution. Si vous avez des questions sur le rôle du coordinateur ou de la coordinatrice des ateliers, ou si vous souhaitez mettre en place des arrangements particuliers pour votre atelier, n'hésitez pas à contacter le coordinateur ou la coordinatrice à admin@datacarpentry.org
+Le⋅a coordinateur⋅rice des ateliers de Data Carpentry se charge de s'assurer que les ateliers soient une expérience enrichissante et de haute qualité pour répondre aux exigences de votre institution. Si vous avez des questions sur le rôle du⋅de la coordinateur⋅rice des ateliers, ou si vous souhaitez mettre en place des arrangements particuliers pour votre atelier, n'hésitez pas à contacter le⋅a coordinateur⋅rice à admin@datacarpentry.org
 
 ### Les Responsabilités du formateur principal/de la formatrice principale
 
-Le formateur principal/la formatrice principale est responsable de la coordination avec les co-formateurs/co-formatrices et l'hôte(sse) du contenu de l'atelier. Ils sont aussi en charge de mettre en place le site internet pour l'atelier et pour la distribution des enquêtes auprès des participant(e)s. Toutes ces tâches peuvent être déléguées, mais c'est au formateur principal/ à la formatrice principale de s'assurer qu'elles soient accomplies. Si vous vous êtes vus assigné le rôle de formateur principal ou formatrices principale mais que vous n'êtes pas confortable dans cette position ou que vous vous rendez compte que vous n'avez pas le temps de remplir les tâches demandées, prenez contact avec le coordinateur ou la coordinatrice de Data Carpentry le plus rapidement possible (admin@datacarpentry.org).
+Le⋅a formateur⋅rice principal⋅e est responsable de la coordination avec les co-formateur⋅rice⋅s et l'hôte⋅sse du contenu de l'atelier. Ils sont aussi en charge de mettre en place le site internet pour l'atelier et pour la distribution des enquêtes auprès des participant⋅e⋅s. Toutes ces tâches peuvent être déléguées, mais c'est au⋅à la formateur⋅rice principal⋅e de s'assurer qu'elles soient accomplies. Si vous vous êtes vus assigné le rôle de formateur⋅rice principal⋅e mais que vous n'êtes pas confortable dans cette position ou que vous vous rendez compte que vous n'avez pas le temps de remplir les tâches demandées, prenez contact avec le⋅a coordinateur⋅rice de Data Carpentry le plus rapidement possible (admin@datacarpentry.org).
 
-Le formateur principal/la formatrice principale est aussi responsable de la préparation du contenu de l'atelier, voir les responsabilités du formateur / de la formatrice ci-dessous.
+Le⋅a formateur⋅rice principal⋅e est aussi responsable de la préparation du contenu de l'atelier, voir les responsabilités du⋅de la formateur⋅rice ci-dessous.
 
 #### Avant l'atelier
 
-- Avec l'hôte(sse) et les autres formateurs/formatrices, décider de ce qui va être enseigné
+- Avec l'hôte⋅sse et les autres formateur⋅rice⋅s, décider de ce qui va être enseigné
   pendant l'atelier et qui enseignera quoi pour chaque leçon
 - Créer un etherpad pour votre atelier à
   http://pad.software-carpentry.org/YYYY-MM-DD-site (où “YYYY-MM-DD-site” est
   l'identifiant pour votre atelier).
 - Créer le [site internet](https://github.com/datacarpentry/workshop-template)
   pour votre atelier
-- Aider l'hôte(sse) à recruter des assistant(e)s pour l'atelier (au moins 1 assistant(e)
-  pour 12 participant(e)s)
-- S'assurer en coordination avec l'hôte(sse) que l'atelier est accessible
+- Aider l'hôte⋅sse à recruter des assistant⋅e⋅s pour l'atelier (au moins 1 assistant⋅e
+  pour 12 participant⋅e⋅s)
+- S'assurer en coordination avec l'hôte⋅sse que l'atelier est accessible
 - Se préparer à enseigner le contenu pédagogique de l'atelier
-- Envoyer un email aux participant(e)s pour leur rappeler du lieu et des heures de
+- Envoyer un email aux participant⋅e⋅s pour leur rappeler du lieu et des heures de
   l'atelier, ainsi que des logiciels et autres pré-requis qu'ils doivent
   installer avant de venir à l'atelier. Cet email doit aussi contenir le lien de
   l'enquête d'avant-atelier.
-- S'assurer avec l'hôte(sse) que tout le matériel nécessaire pour l'atelier est
+- S'assurer avec l'hôte⋅sse que tout le matériel nécessaire pour l'atelier est
   disponible, en particulier les post-its.
 
 #### Pendant l'atelier
 
-- S'assurer que les noms et adresses électroniques des participant(e)s sont collectés pendant
+- S'assurer que les noms et adresses électroniques des participant⋅e⋅s sont collectés pendant
   l'atelier
 - Envoyer le lien, et s'assurer de la complétion de l'enquête d'après atelier.
 
 #### Après l'atelier
 
-- Coordonner avec l'hôte(sse) pour envoyer au coordinateur ou à la coordinatrice de Data Carpentry les informations sur les participants à l'atelier.
-- Compléter les mêmes taches d'après atelier que les formateurs/formatrices
+- Coordonner avec l'hôte⋅sse pour envoyer au⋅à la coordinateur⋅rice de Data Carpentry les informations sur les participant⋅e⋅s à l'atelier.
+- Compléter les mêmes taches d'après atelier que les formateur⋅rice⋅s
 
 ### Les Responsabilités de tous les formateurs/formatrices
 
-Chaque formateur/formatrices est responsable de la préparation de l'enseignement de leur(s) section(s). N'oubliez pas que le contenu de nos leçon évolue sans cesse, et que même si vous avez enseigné dans le passé, vous devrez vérifier le contenu pour tout changement éventuel.
+Chaque formateur⋅rice est responsable de la préparation de l'enseignement de leur(s) section(s). N'oubliez pas que le contenu de nos leçon évolue sans cesse, et que même si vous avez enseigné dans le passé, vous devrez vérifier le contenu pour tout changement éventuel.
 
 #### Avant l'atelier
 
-- Coordonner avec le formateur principal/la formatrice principale pour décider qui enseigne quoi, et
+- Coordonner avec le⋅a formateur⋅rice principal⋅e pour décider qui enseigne quoi, et
   dans quel ordre.
-- Si votre atelier est organisé en autonomie, et que vous n'ếtes pas un
-  formateur/une formatrice Data Carpentry certifié(e), vous devrez organiser une réunion avec le formateur principal/la formatrice principale pour être formé aux pratiques pédagogiques de Data
+- Si votre atelier est organisé en autonomie, et que vous n'ếtes pas un⋅e
+  formateur⋅rice Data Carpentry certifié⋅e, vous devrez organiser une réunion avec le⋅a formateur⋅rice principal⋅e pour être formé⋅e aux pratiques pédagogiques de Data
   Carpentry.
 - Tester que les instructions pour l'installation des logiciels et données pour
   l'atelier fonctionnent correctement
@@ -166,22 +166,22 @@ Chaque formateur/formatrices est responsable de la préparation de l'enseignemen
 
 #### Pendant l'atelier
 
-- Rappeler aux participant(e)s de l'existence d'un code de conduite
-- Rappeler aux participant(e)s comment utiliser les post-its
-- Demander aux participant(e)s des commentaires à la mi-journée et en fin de journée
+- Rappeler aux participant⋅e⋅s de l'existence d'un code de conduite
+- Rappeler aux participant⋅e⋅s comment utiliser les post-its
+- Demander aux participant⋅e⋅s des commentaires à la mi-journée et en fin de journée
 
 
 #### Après l'atelier
 
 - Participer à une discussion d'après-atelier en ligne
-- Envoyer tout commentaire au coordinateur ou à la coordinatrice de Data Carpentry
+- Envoyer tout commentaire au⋅à la coordinateur⋅rice de Data Carpentry
 - Signaler tout problème avec les instructions d'installation
 - Signaler toute erreur dans les leçons, ou suggérer des améliorations soit par
   GitHub ou par email.
 
 ## Ateliers organisés en autonomie
 
-Êtes-vous un formateur/une formatrice pour Data Carpentry intéressé par l'organisation d'un atelier pour votre groupe ou votre organisation ? Pour les ateliers organisés par Data Carpentry, pour s'assurer de la qualité de l'organisation et des communications avant et après l'atelier, le personnel de Data Carpentry se charge de toute la logistique non-locale qui inclut l'inscription des participant(e)s, la mise en place du programme, la communication avec les participant(e)s, la distributions des enquêtes, et le recrutement des formateurs/formatrices. Dans le cas d'un atelier organisé en autonomie, c'est un organisateur local ou une organisatrice locale qui se charge de toute la logistique de la mise en place de l'atelier sans l'aide du personnel de Data Carpentry. Data Carpentry doit cependant être informé des ateliers organisés en autonomie.
+Êtes-vous un⋅e formateur⋅rice pour Data Carpentry intéressé⋅e par l'organisation d'un atelier pour votre groupe ou votre organisation ? Pour les ateliers organisés par Data Carpentry, pour s'assurer de la qualité de l'organisation et des communications avant et après l'atelier, le personnel de Data Carpentry se charge de toute la logistique non-locale qui inclut l'inscription des participant⋅e⋅s, la mise en place du programme, la communication avec les participant⋅e⋅s, la distributions des enquêtes, et le recrutement des formateur⋅rice⋅s. Dans le cas d'un atelier organisé en autonomie, c'est un⋅e organisateur⋅rice local⋅e qui se charge de toute la logistique de la mise en place de l'atelier sans l'aide du personnel de Data Carpentry. Data Carpentry doit cependant être informé des ateliers organisés en autonomie.
 
 ## Modèles de courriels
 
@@ -189,25 +189,25 @@ Ces modèles de courriels sont seulement fournis à titre indicatif. Nous espér
 
 ### Pour les ateliers organisés en autonomie seulement
 
-#### Recruter des co-formateurs/co-formatrices (aussi appelé(e)s assistant(e)s)
+#### Recruter des co-formateur⋅rice⋅s (aussi appelé⋅e⋅s assistant⋅e⋅s)
 
 Bonjour [nom],
 
-J'organise un atelier Data Carpentry en [mois prévu]. Data Carpentry est une organisation à but non-lucratif qui aide les chercheurs à apprendre comment organiser et analyser leurs données de manière efficace et reproductible. Ces ateliers enseignent des compétences qui sont immédiatement utiles aux chercheurs, en utilisant des jeux de données spécifiques à leur domaine d'expertise, afin qu'ils puissent appliquer rapidement ce qu'ils apprennent à leur propres données. Je suis très enthousiaste à l'idée d'utiliser le contenu des ateliers Data Carpentry ici pour aider nos [thésards/thésards, équipes, personnels, enseignants/enseignantes, chercheurs/chercheuses... ] à être plus efficaces dans leur recherche.
+J'organise un atelier Data Carpentry en [mois prévu]. Data Carpentry est une organisation à but non-lucratif qui aide les chercheur⋅se⋅s à apprendre comment organiser et analyser leurs données de manière efficace et reproductible. Ces ateliers enseignent des compétences qui sont immédiatement utiles aux chercheur⋅se⋅s, en utilisant des jeux de données spécifiques à leur domaine d'expertise, afin qu'ils puissent appliquer rapidement ce qu'ils apprennent à leur propres données. Je suis très enthousiaste à l'idée d'utiliser le contenu des ateliers Data Carpentry ici pour aider nos [doctorant⋅e⋅s, équipes, personnels, enseignant⋅e⋅s, chercheur⋅se⋅s... ] à être plus efficaces dans leur recherche.
 
-J'ai suivi la formation pédagogique pour devenir formateur Data Carpentry, et je suis certifié-e pour enseigner leurs ateliers. Afin d'organiser un de leurs atelier, je vais avoir besoin d'un (préféremment deux) co-formateurs/co-formatrices pour m'aider à enseigner le contenu de l'atelier. Ces ateliers durent deux jours et les formateurs/formatrices généralement alternent après chaque demi-journée. Je pense couvrir [les sujets de votre atelier], et j'espérai que tu puisses enseigner le module sur [sujet]. Data Carpentry fournit des leçons qui sont prêtes à être enseignées, donc nous n'aurons pas à tout faire de zéro. Si tu es intéressé, tu peux voir le contenu sur [sujet] ici [lien vers la leçon], et le reste du contenu de leurs ateliers ici: http://datacarpentry.org/lessons
+J'ai suivi la formation pédagogique pour devenir formateur Data Carpentry, et je suis certifié⋅e pour enseigner leurs ateliers. Afin d'organiser un de leurs atelier, je vais avoir besoin d'un (préféremment deux) co-formateur⋅rice⋅s pour m'aider à enseigner le contenu de l'atelier. Ces ateliers durent deux jours et les formateur⋅rice⋅s généralement alternent après chaque demi-journée. Je pense couvrir [les sujets de votre atelier], et j'espérai que tu puisses enseigner le module sur [sujet]. Data Carpentry fournit des leçons qui sont prêtes à être enseignées, donc nous n'aurons pas à tout faire de zéro. Si tu es intéressé⋅e, tu peux voir le contenu sur [sujet] ici [lien vers la leçon], et le reste du contenu de leurs ateliers ici: http://datacarpentry.org/lessons
 
-Si tu es intéressé-e pour être un co-formateur, dis-le moi et nous pouvons nous voir pour nous organiser. Si tu connais d'autres personnes qui seraient intéressées pour nous aider, n'hésite pas à les contacter.
+Si tu es intéressé⋅e pour être un⋅e co-formateur⋅rice, dis-le moi et nous pouvons nous voir pour nous organiser. Si tu connais d'autres personnes qui seraient intéressées pour nous aider, n'hésite pas à les contacter.
 
 ### Pour tous les ateliers
 
-#### Recruter des assistant(e)s
+#### Recruter des assistant⋅e⋅s
 
 Bonjour [nom],
 
-J'organise un atelier Data Carpentry en [mois prévu]. Data Carpentry est une organisation à but non-lucratif qui aide les chercheurs/chercheuses à apprendre comment organiser et analyser leurs données de manière efficace et reproductible. Ces ateliers enseignent des compétences qui sont immédiatement utiles aux chercheurs/chercheuses, en utilisant des jeux de données spécifiques à leur domaine d'expertise, afin qu'ils puissent appliquer rapidement ce qu'ils apprennent à leur propres données. Je suis très enthousiaste à l'idée d'utiliser le contenu des ateliers Data Carpentry ici pour aider nos [thésards/thésards, équipes, personnels, enseignants/enseignantes, chercheurs/chercheuses... ] à être plus efficaces dans leur recherche.
+J'organise un atelier Data Carpentry en [mois prévu]. Data Carpentry est une organisation à but non-lucratif qui aide les chercheur⋅se⋅s à apprendre comment organiser et analyser leurs données de manière efficace et reproductible. Ces ateliers enseignent des compétences qui sont immédiatement utiles aux chercheur⋅se⋅s, en utilisant des jeux de données spécifiques à leur domaine d'expertise, afin qu'ils puissent appliquer rapidement ce qu'ils apprennent à leur propres données. Je suis très enthousiaste à l'idée d'utiliser le contenu des ateliers Data Carpentry ici pour aider nos [doctorant⋅e⋅s, équipes, personnels, enseignant⋅e⋅s, chercheur⋅se⋅s... ] à être plus efficaces dans leur recherche.
 
-Pendant l'atelier, je vais avoir besoin d'assistant(e)s pour aider au cas où des participant(e)s sont confronté(e)s à des problèmes ou sont bloqué(e)s. Les assistant(e)s pour ces ateliers se déplacent parmi les participant(e)s pour répondre à leurs questions et les aider s'ils ont des problèmes d'installation, des messages d'erreur, ou ont des résultats inattendus. Tu n'as pas besoin d'être un(e) expert(e) dans les outils que l'on utilise pendant cet atelier, juste que tu saches les utiliser pour pouvoir dépanner quelqu'un qui s'en sert pour la première fois. Pendant cet atelier, nous pensons parler de [liste des sujets], et je pense que tu pourras beaucoup nous aider. Si tu es intéressé-e, tu peux voir le contenu des leçons que nous enseigneront ici [liens]. N'hésite pas à me contacter si tu es intéressé-e pour être un de nos assistant(e)s, et si tu connais d'autres personnes qui seraient susceptibles de nous aider.
+Pendant l'atelier, je vais avoir besoin d'assistant⋅e⋅s pour aider au cas où des participant⋅e⋅s sont confronté⋅e⋅s à des problèmes ou sont bloqué⋅e⋅s. Les assistant⋅e⋅s pour ces ateliers se déplacent parmi les participant⋅e⋅s pour répondre à leurs questions et les aider s'ils ont des problèmes d'installation, des messages d'erreur, ou ont des résultats inattendus. Tu n'as pas besoin d'être un⋅e expert⋅e dans les outils que l'on utilise pendant cet atelier, juste que tu saches les utiliser pour pouvoir dépanner quelqu'un qui s'en sert pour la première fois. Pendant cet atelier, nous pensons parler de [liste des sujets], et je pense que tu pourras beaucoup nous aider. Si tu es intéressé⋅e, tu peux voir le contenu des leçons que nous enseigneront ici [liens]. N'hésite pas à me contacter si tu es intéressé⋅e pour être un⋅e de nos assistant⋅e⋅s, et si tu connais d'autres personnes qui seraient susceptibles de nous aider.
 
 #### Annoncer votre atelier
 
@@ -220,19 +220,19 @@ Le [date], [nom de l'institution/organisation] accueille un atelier Data Carpent
 - [leçon]
 - [leçon]
 
-Ces ateliers sont destinées à ceux qui ont peu ou pas d'expérience en programmation, et les formateurs/formatrices font l'une de leur priorités de créer un environement accueillant pour donner aux chercheurs/chercheuses la confiance dont ils ont besoin pour qu'ils puissent utiliser leurs données pour faire des découvertes. Les participant(e)s qui ont déjà un peu d'expérience profiteront de cet atelier, car le but n'est pas seulement d'enseigner comment faire des analyses, mais aussi comment organiser ses analyses pour automatiser le processus et le rendre reproductible.
+Ces ateliers sont destinées à ceux qui ont peu ou pas d'expérience en programmation, et les formateur⋅rice⋅s font l'une de leur priorités de créer un environement accueillant pour donner aux chercheur⋅se⋅s la confiance dont ils ont besoin pour qu'ils puissent utiliser leurs données pour faire des découvertes. Les participant⋅e⋅s qui ont déjà un peu d'expérience profiteront de cet atelier, car le but n'est pas seulement d'enseigner comment faire des analyses, mais aussi comment organiser ses analyses pour automatiser le processus et le rendre reproductible.
 
 Le nombre de places pour cet atelier est limité, et il est probable que l'atelier soit complet rapidement. [Ajouter une phrase pour préciser si l'atelier est gratuit ou s'il y a des frais d'inscriptions à payer]. Pour vous inscrire, cliquer ici [lien vers la page d'inscription], et pour plus d'informations, vous pouvez visiter la page de l'atelier ici [lien vers le site internet de l'atelier].
 
-##### Email à envoyer aux participant(e)s avant l'atelier
+##### Email à envoyer aux participant⋅e⋅s avant l'atelier
 
 Bonjour,
 
-Nous sommes impatient(e)s pour l'atelier Data Carpentry qui aura lieu [jour et dates] et nous espérons que vous l'êtes aussi. Voici quelques rappels en préparation pour l'atelier :
+Nous sommes impatient⋅e⋅s pour l'atelier Data Carpentry qui aura lieu [jour et dates] et nous espérons que vous l'êtes aussi. Voici quelques rappels en préparation pour l'atelier :
 
-Soyez sûr-e que vous ayez complété l'enquête d'avant-atelier [lien vers l'enquête]. Nous utilisons ces informations pour adapter le contenu, et la vitesse de l'instruction, et avec les résultat de l'enquête d'après-atelier, pour mesurer le succès de l'atelier.
+Soyez sûr⋅e que vous ayez complété l'enquête d'avant-atelier [lien vers l'enquête]. Nous utilisons ces informations pour adapter le contenu, et la vitesse de l'instruction, et avec les résultat de l'enquête d'après-atelier, pour mesurer le succès de l'atelier.
 
-Soyez sûr-e que tous les logiciels nécessaires soient installés sur votre ordinateur portable. La liste est disponible ici [lien vers le site de l'atelier] et les instructions [lien vers les instructions]. Si vous rencontrez des difficultés, envoyez à la personne listée sur le site internet de l'atelier un email, ou venez avant [heure] le premier jour de l'atelier pour que nous puissions vous aider.
+Soyez sûr⋅e que tous les logiciels nécessaires soient installés sur votre ordinateur portable. La liste est disponible ici [lien vers le site de l'atelier] et les instructions [lien vers les instructions]. Si vous rencontrez des difficultés, envoyez à la personne listée sur le site internet de l'atelier un email, ou venez avant [heure] le premier jour de l'atelier pour que nous puissions vous aider.
 
 [Dire si l'hôte fournira thé, café, collations, pendant les pauses]
 
@@ -246,16 +246,16 @@ Voici quelque liens vers des ressources que vous utiliserons pendant l'atelier :
 
 Pour trouver la salle où se déroulera l'atelier : [ajouter les indications pour accéder au bâtiment et à la salle].
 
-Merci de lire le code de conduite pour Data Carpentry [http://datacarpentry.org/code-of-conduct] afin que nous soyons tous et toutes au point sur la manière de traiter tou(te)s les participant(e)s, les formateurs/formatrices, et les assistant(e)s avec respect.
+Merci de lire le code de conduite pour Data Carpentry [http://datacarpentry.org/code-of-conduct] afin que nous soyons tous et toutes au point sur la manière de traiter tou⋅te⋅s les participant⋅e⋅s, les formateur⋅rice⋅s, et les assistant⋅e⋅s avec respect.
 
 N'hésitez pas à nous contacter si vous avez des questions, sinon à [jour de l'atelier] !
 
 
-#### Email à envoyer aux participant(e)s après l'atelier
+#### Email à envoyer aux participant⋅e⋅s après l'atelier
 
 Bonjour,
 
-Merci d'avoir participé à notre atelier Data Carpentry. Nous espérons que vous avez appris beaucoup et que vous vous êtes amusés.
+Merci d'avoir participé à notre atelier Data Carpentry. Nous espérons que vous avez appris beaucoup et que vous vous êtes amusé⋅e⋅s.
 
 Si vous ne l'avez pas déjà fait, n'oubliez pas de remplir notre enquête d'après-atelier [lien]. Vos réponses sont essentielles pour nous permettre d'améliorer en permanence nos ateliers pour nos futurs participants.
 

--- a/fr-organisation.md
+++ b/fr-organisation.md
@@ -116,7 +116,7 @@ Le⋅a formateur⋅rice principal⋅e est aussi responsable de la préparation d
 #### Avant l'atelier
 
 - Avec l'hôte⋅esse et les autres formateur⋅rice⋅s, décider de ce qui va être enseigné
-  pendant l'atelier et qui enseignera quoi pour chaque leçon
+  pendant l'atelier et qui enseignera quoi pour chaque cours
 - Créer un etherpad pour votre atelier à
   http://pad.software-carpentry.org/YYYY-MM-DD-site (où “YYYY-MM-DD-site” est
   l'identifiant pour votre atelier).
@@ -146,7 +146,7 @@ Le⋅a formateur⋅rice principal⋅e est aussi responsable de la préparation d
 
 ### Les Responsabilités de tous les formateur⋅rice⋅s
 
-Chaque formateur⋅rice est responsable de la préparation de l'enseignement de leur(s) section(s). N'oubliez pas que le contenu de nos leçons évolue sans cesse, et que même si vous avez enseigné dans le passé, vous devrez vérifier le contenu des leçons pour tout changement éventuel.
+Chaque formateur⋅rice est responsable de la préparation de l'enseignement de leur(s) section(s). N'oubliez pas que le contenu de nos cours évolue sans cesse, et que même si vous avez enseigné dans le passé, vous devrez vérifier le contenu des cours pour tout changement éventuel.
 
 #### Avant l'atelier
 
@@ -157,10 +157,10 @@ Chaque formateur⋅rice est responsable de la préparation de l'enseignement de 
   Carpentry.
 - Tester que les instructions pour l'installation des logiciels et données pour
   l'atelier fonctionnent correctement
-- Lire les leçons que vous allez enseigner en détail
-- S'il y a un guide d'enseignement pour les leçons que vous allez enseigner, le
+- Lire les cours que vous allez enseigner en détail
+- S'il y a un guide d'enseignement pour les cours que vous allez enseigner, le
   lire en détail
-- Faire une répétition de l'ensemble de la leçon
+- Faire une répétition de l'ensemble de la cours
 - Lire le guide de dépannage
 
 #### Pendant l'atelier
@@ -175,7 +175,7 @@ Chaque formateur⋅rice est responsable de la préparation de l'enseignement de 
 - Participer à une discussion d'après-atelier en ligne
 - Envoyer tout commentaire au⋅à la coordinateur⋅rice de Data Carpentry
 - Signaler tout problème avec les instructions d'installation
-- Signaler toute erreur dans les leçons, ou suggérer des améliorations soit par
+- Signaler toute erreur dans les cours, ou suggérer des améliorations soit par
   GitHub ou par email.
 
 ## Ateliers organisés en autonomie
@@ -194,7 +194,7 @@ Bonjour [nom],
 
 J'organise un atelier Data Carpentry en [mois prévu]. Data Carpentry est une organisation à but non-lucratif qui aide les chercheur⋅se⋅s à apprendre comment organiser et analyser leurs données de manière efficace et reproductible. Ces ateliers enseignent des compétences qui sont immédiatement utiles aux chercheur⋅se⋅s, en utilisant des jeux de données spécifiques à leur domaine d'expertise, afin qu'ils puissent appliquer rapidement ce qu'ils apprennent à leur propres données. Je suis très enthousiaste à l'idée d'utiliser le contenu des ateliers Data Carpentry ici pour aider nos [doctorant⋅e⋅s, équipes, personnels, enseignant⋅e⋅s, chercheur⋅se⋅s... ] à être plus efficaces dans leur recherche.
 
-J'ai suivi la formation pédagogique pour devenir formateur Data Carpentry, et je suis certifié⋅e pour enseigner leurs ateliers. Afin d'organiser un de leurs atelier, je vais avoir besoin d'un (préféremment deux) co-formateur⋅rice⋅s pour m'aider à enseigner le contenu de l'atelier. Ces ateliers durent deux jours et les formateur⋅rice⋅s généralement changent après chaque demi-journée. Je pense couvrir [les sujets de votre atelier], et j'espérai que tu puisses enseigner le module sur [sujet]. Data Carpentry fournit des leçons qui sont prêtes à être enseignées, donc nous n'aurons pas à partir de zéro. Si tu es intéressé⋅e, tu peux voir le contenu sur [sujet] ici [lien vers la leçon], et le reste du contenu de leurs ateliers ici: http://datacarpentry.org/lessons
+J'ai suivi la formation pédagogique pour devenir formateur Data Carpentry, et je suis certifié⋅e pour enseigner leurs ateliers. Afin d'organiser un de leurs atelier, je vais avoir besoin d'un (préféremment deux) co-formateur⋅rice⋅s pour m'aider à enseigner le contenu de l'atelier. Ces ateliers durent deux jours et les formateur⋅rice⋅s généralement changent après chaque demi-journée. Je pense couvrir [les sujets de votre atelier], et j'espérai que tu puisses enseigner le module sur [sujet]. Data Carpentry fournit des cours qui sont prêtes à être enseignées, donc nous n'aurons pas à partir de zéro. Si tu es intéressé⋅e, tu peux voir le contenu sur [sujet] ici [lien vers la cours], et le reste du contenu de leurs ateliers ici: http://datacarpentry.org/lessons
 
 Si tu es intéressé⋅e pour être un⋅e co-formateur⋅rice, dis-le moi et nous pouvons nous voir pour nous organiser. Si tu connais d'autres personnes qui seraient intéressées pour nous aider, n'hésite pas à les contacter.
 
@@ -206,18 +206,18 @@ Bonjour [nom],
 
 J'organise un atelier Data Carpentry en [mois prévu]. Data Carpentry est une organisation à but non-lucratif qui aide les chercheur⋅se⋅s à apprendre comment organiser et analyser leurs données de manière efficace et reproductible. Ces ateliers enseignent des compétences qui sont immédiatement utiles aux chercheur⋅se⋅s, en utilisant des jeux de données spécifiques à leur domaine d'expertise, afin qu'ils puissent appliquer rapidement ce qu'ils apprennent à leur propres données. Je suis très enthousiaste à l'idée d'utiliser le contenu des ateliers Data Carpentry ici pour aider nos [doctorant⋅e⋅s, équipes, personnels, enseignant⋅e⋅s, chercheur⋅se⋅s... ] à être plus efficaces dans leur recherche.
 
-Pendant l'atelier, je vais avoir besoin d'assistant⋅e⋅s pour aider au cas où des participant⋅e⋅s sont confronté⋅e⋅s à des problèmes ou sont bloqué⋅e⋅s. Les assistant⋅e⋅s pour ces ateliers se déplacent parmi les participant⋅e⋅s pour répondre à leurs questions et les aider s'ils ont des problèmes d'installation, des messages d'erreur, ou ont des résultats inattendus. Tu n'as pas besoin d'être un⋅e expert⋅e dans les outils que l'on utilise pendant cet atelier, juste que tu saches les utiliser pour pouvoir dépanner quelqu'un qui s'en sert pour la première fois. Pendant cet atelier, nous pensons parler de [liste des sujets], et je pense que tu pourras beaucoup nous aider. Si tu es intéressé⋅e, tu peux voir le contenu des leçons que nous enseigneront ici [liens]. N'hésite pas à me contacter si tu es intéressé⋅e pour être un⋅e de nos assistant⋅e⋅s, et si tu connais d'autres personnes qui seraient susceptibles de nous aider.
+Pendant l'atelier, je vais avoir besoin d'assistant⋅e⋅s pour aider au cas où des participant⋅e⋅s sont confronté⋅e⋅s à des problèmes ou sont bloqué⋅e⋅s. Les assistant⋅e⋅s pour ces ateliers se déplacent parmi les participant⋅e⋅s pour répondre à leurs questions et les aider s'ils ont des problèmes d'installation, des messages d'erreur, ou ont des résultats inattendus. Tu n'as pas besoin d'être un⋅e expert⋅e dans les outils que l'on utilise pendant cet atelier, juste que tu saches les utiliser pour pouvoir dépanner quelqu'un qui s'en sert pour la première fois. Pendant cet atelier, nous pensons parler de [liste des sujets], et je pense que tu pourras beaucoup nous aider. Si tu es intéressé⋅e, tu peux voir le contenu des cours que nous enseigneront ici [liens]. N'hésite pas à me contacter si tu es intéressé⋅e pour être un⋅e de nos assistant⋅e⋅s, et si tu connais d'autres personnes qui seraient susceptibles de nous aider.
 
 #### Annoncer votre atelier
 
 [Nom de l'institution/organisation] atelier Data Carpentry [dates, lieu]
 
-Le [date], [nom de l'institution/organisation] accueille un atelier Data Carpentry pour [audience cible, sujet]. Les ateliers Data Carpentry enseignent les compétences nécessaires pour débuter avec l'organisation et l'analyse des données dans tous les domaines de recherche. Leur mission est de fournir aux chercheur⋅se⋅s une formation accueillante, de haute qualité qui couvre tout le cycle de vie de la recherche basée sur les données. Les leçons sont spécifiques à des domaines de recherche, et cet atelier se focalise sur [sujet]. Le contenu de l'atelier contiendra :
+Le [date], [nom de l'institution/organisation] accueille un atelier Data Carpentry pour [audience cible, sujet]. Les ateliers Data Carpentry enseignent les compétences nécessaires pour débuter avec l'organisation et l'analyse des données dans tous les domaines de recherche. Leur mission est de fournir aux chercheur⋅se⋅s une formation accueillante, de haute qualité qui couvre tout le cycle de vie de la recherche basée sur les données. Les cours sont spécifiques à des domaines de recherche, et cet atelier se focalise sur [sujet]. Le contenu de l'atelier contiendra :
 
-- [leçon]
-- [leçon]
-- [leçon]
-- [leçon]
+- [cours]
+- [cours]
+- [cours]
+- [cours]
 
 Ces ateliers sont destinées à ceux⋅elles qui ont peu ou pas d'expérience en programmation, et les formateur⋅rice⋅s font l'une de leur priorités de créer un environement accueillant pour donner aux chercheur⋅se⋅s la confiance dont ils ont besoin pour qu'ils puissent utiliser leurs données pour faire des découvertes. Les participant⋅e⋅s qui ont déjà un peu d'expérience profiteront de cet atelier, car le but n'est pas seulement d'enseigner comment faire des analyses, mais aussi comment organiser ses analyses pour automatiser le processus et le rendre reproductible.
 
@@ -241,7 +241,7 @@ Voici quelque liens vers des ressources que vous utiliserons pendant l'atelier :
 
 - site internet de l'atelier: [lien]
 - etherpad: [lien]
-[- leçons: [lien] ]
+[- cours: [lien] ]
 
 Pour trouver la salle où se déroulera l'atelier : [ajouter les indications pour accéder au bâtiment et à la salle].
 
@@ -258,6 +258,6 @@ Merci d'avoir participé⋅e à notre atelier Data Carpentry. Nous espérons que
 
 Si vous ne l'avez pas déjà fait, n'oubliez pas de remplir notre enquête d'après-atelier [lien]. Vos réponses sont essentielles pour nous permettre d'améliorer en permanence nos ateliers pour nos futurs participants.
 
-Si vous avez des commentaires sur l'atelier, ou que vous souhaitez vous impliquer dans la communauté de Data Carpentry, n'hésitez pas à nous contacter (admin@datacarpentry.org). Vous pouvez aussi joindre notre liste de discussion (http://lists.software-carpentry.org/listinfo/discuss), nous suivre sur Twitter (@DataCarpentry), ou vous impliquer dans le développement de nos leçons sur GitHub (https://github.com/datacarpentry).
+Si vous avez des commentaires sur l'atelier, ou que vous souhaitez vous impliquer dans la communauté de Data Carpentry, n'hésitez pas à nous contacter (admin@datacarpentry.org). Vous pouvez aussi joindre notre liste de discussion (http://lists.software-carpentry.org/listinfo/discuss), nous suivre sur Twitter (@DataCarpentry), ou vous impliquer dans le développement de nos cours sur GitHub (https://github.com/datacarpentry).
 
 Nous espérons que nous aurons l'occasion de vous revoir dans votre poursuite de l'amélioration de vos compétences en l'analyse de données.

--- a/fr-organisation.md
+++ b/fr-organisation.md
@@ -21,11 +21,11 @@
   l'atelier. Le⋅a formateur⋅rice principal⋅e se chargera aussi de communiquer avec le
   personnel de Data Carpentry au besoin.
 
-* L'hôte⋅sse (l'organisateur⋅rice de l'atelier, vous) doit se charger de l'organisation sur
+* L'hôte⋅esse (l'organisateur⋅rice de l'atelier, vous) doit se charger de l'organisation sur
   place : réservation de la salle, s'assurer du nombre suffisant de prises
   électriques, mise à disposition de café, etc.
 
-* L'hôte⋅sse et les formateur⋅rice⋅s organiseront ensemble les
+* L'hôte⋅esse et les formateur⋅rice⋅s organiseront ensemble les
   déplacements avant l'atelier. Les formateur⋅rice⋅s ne connaîtront pas les lieux,
   et apprécieront donc l'aide que vous pourrez leur apporter pour la réservation de leur hôtel et
   le transport depuis l'aéroport.
@@ -43,7 +43,7 @@ Le coût de l'organisation d'un atelier comprend non seulement les frais adminis
   par cas.
 
 * **Frais de déplacements pour les formateurs**: ~ US$2000. Tous nos
-  formateur⋅rice⋅s sont des volontaires, mais l'hôte⋅sse s'engage à couvrir la totalité
+  formateur⋅rice⋅s sont des volontaires, mais l'hôte⋅esse s'engage à couvrir la totalité
   de leurs frais de déplacement. Nous essayons de recruter des formateur⋅rice⋅s
   proches, mais nous suggérons que vous budgétisez environ $2000 pour les frais
   de déplacement, les repas, et l'hébergement des formateur⋅rice⋅s. Les détails des
@@ -52,9 +52,9 @@ Le coût de l'organisation d'un atelier comprend non seulement les frais adminis
 
 &ast; 50% des frais administratifs pour les ateliers organisés par des organisations à but lucratif servent à financer les ateliers dans des zones qui ont des difficultés financières.
 
-### Les Responsabilités de l'hôte⋅sse
+### Les Responsabilités de l'hôte⋅esse
 
-Pour les ateliers organisés par Data Carpentry, les hôte⋅sse⋅s sont responsables de toute la logistique locale, alors que le⋅a coordinateur⋅rice de Data Carpentry se charge du reste (voir paragraphe ci-dessous). Si votre atelier est organisé en autonomie, l'hôte⋅sse est en charge de toute l'organisation (voir section "Ateliers organisés en autonomie").
+Pour les ateliers organisés par Data Carpentry, les hôte⋅esse⋅s sont responsables de toute la logistique locale, alors que le⋅a coordinateur⋅rice de Data Carpentry se charge du reste (voir paragraphe ci-dessous). Si votre atelier est organisé en autonomie, l'hôte⋅esse est en charge de toute l'organisation (voir section "Ateliers organisés en autonomie").
 
 - Choisir le [programme](http://www.datacarpentry.org/workshops/) qui sera le
   plus approprié pour vos participant⋅e⋅s
@@ -71,7 +71,7 @@ Pour les ateliers organisés par Data Carpentry, les hôte⋅sse⋅s sont respon
 	* la salle peut accueillir les chiens guides.
 	* un microphone est disponible pour le⋅a formateur⋅rice
 	* l'écran du projecteur est suffisamment grand pour être facile à lire.
-	* Si des participants, les formateur⋅rice⋅s, ou les assistant⋅e⋅s indiquent à l'avance des besoins particuliers, l'hôte⋅sse est en charge de s'assurer que tout est en place pour le jour de l'atelier. L'institution hôte⋅sse a peut être un service d'aide et d'accompagnement aux personnes handicapées qui puisse vous aider.
+	* Si des participants, les formateur⋅rice⋅s, ou les assistant⋅e⋅s indiquent à l'avance des besoins particuliers, l'hôte⋅esse est en charge de s'assurer que tout est en place pour le jour de l'atelier. L'institution hôte⋅esse a peut être un service d'aide et d'accompagnement aux personnes handicapées qui puisse vous aider.
 - Recruter des assistant⋅e⋅s pour l'atelier (au moins un⋅e assistant⋅e pour 12
   participants).
 - Annoncer l'atelier
@@ -94,43 +94,43 @@ Pour les ateliers organisés par Data Carpentry, les hôte⋅sse⋅s sont respon
 
 Pour les ateliers organisés par Data Carpentry, notre coordinateur⋅rice se chargera de :
 
-- Aider l'hôte⋅sse dans le choix de la date et du lieu pour leur atelier
+- Aider l'hôte⋅esse dans le choix de la date et du lieu pour leur atelier
 - Recruter et choisir des formateur⋅rice⋅s qui correspondent aux contraintes de l'hôte
-- Aider l'hôte⋅sse à recruter des assistant⋅e⋅s locaux (si demandé)
+- Aider l'hôte⋅esse à recruter des assistant⋅e⋅s locaux (si demandé)
 - Mettre en place les enquêtes d'avant et d'après atelier qui seront distribués par les formateur⋅rice⋅s aux participant⋅e⋅s
 - Communiquer avec les formateur⋅rice⋅s pour s'assurer que la plannification et l'enseignement se déroulent dans de bonnes conditions
 - Installer et admnistrer la page d'inscription pour l'atelier
 - Enregister les informations pertinentes pour chaque atelier dans la base de données interne à Data Carpentry
 - Aider à diffuser l'annonce de l'atelier sur le compte Twitter de Data Carpentry et sur les listes de discussions (si demandé)
 - Contacter les formateur⋅rice⋅s pour participer aux discussions d'après atelier
-- Servir de point de contact pour l'hôte⋅sse et les formateur⋅rice⋅s pour répondre aux questions et fournir des ressources supplémentaires si besoin.
+- Servir de point de contact pour l'hôte⋅esse et les formateur⋅rice⋅s pour répondre aux questions et fournir des ressources supplémentaires si besoin.
 
 Le⋅a coordinateur⋅rice des ateliers de Data Carpentry doit s'assurer que les ateliers soient une expérience enrichissante et de haute qualité pour répondre aux exigences de votre institution. Si vous avez des questions sur le rôle du⋅de la coordinateur⋅rice des ateliers, ou si vous souhaitez mettre en place des dispositions particulières pour votre atelier, n'hésitez pas à contacter le⋅a coordinateur⋅rice à admin@datacarpentry.org
 
 ### Les Responsabilités du formateur principal/de la formatrice principale
 
-Le⋅a formateur⋅rice principal⋅e est responsable de la coordination avec les co-formateur⋅rice⋅s et l'hôte⋅sse du contenu de l'atelier. Il⋅elle⋅s s'occupent de mettre en place le site internet pour l'atelier et pour la distribution des enquêtes auprès des participant⋅e⋅s. Toutes ces tâches peuvent être déléguées, mais c'est au⋅à la formateur⋅rice principal⋅e de s'assurer qu'elles soient accomplies. Si vous vous êtes vu⋅e⋅s assigné⋅e le rôle de formateur⋅rice principal⋅e mais que vous n'êtes pas confortable dans cette position ou que vous vous rendez compte que vous n'avez pas le temps de remplir les tâches demandées, prenez contact avec le⋅a coordinateur⋅rice de Data Carpentry le plus rapidement possible (admin@datacarpentry.org).
+Le⋅a formateur⋅rice principal⋅e est responsable de la coordination avec les co-formateur⋅rice⋅s et l'hôte⋅esse du contenu de l'atelier. Il⋅elle⋅s s'occupent de mettre en place le site internet pour l'atelier et pour la distribution des enquêtes auprès des participant⋅e⋅s. Toutes ces tâches peuvent être déléguées, mais c'est au⋅à la formateur⋅rice principal⋅e de s'assurer qu'elles soient accomplies. Si vous vous êtes vu⋅e⋅s assigné⋅e le rôle de formateur⋅rice principal⋅e mais que vous n'êtes pas confortable dans cette position ou que vous vous rendez compte que vous n'avez pas le temps de remplir les tâches demandées, prenez contact avec le⋅a coordinateur⋅rice de Data Carpentry le plus rapidement possible (admin@datacarpentry.org).
 
 Le⋅a formateur⋅rice principal⋅e est aussi responsable de la préparation du contenu de l'atelier, voir les responsabilités du⋅de la formateur⋅rice ci-dessous.
 
 #### Avant l'atelier
 
-- Avec l'hôte⋅sse et les autres formateur⋅rice⋅s, décider de ce qui va être enseigné
+- Avec l'hôte⋅esse et les autres formateur⋅rice⋅s, décider de ce qui va être enseigné
   pendant l'atelier et qui enseignera quoi pour chaque leçon
 - Créer un etherpad pour votre atelier à
   http://pad.software-carpentry.org/YYYY-MM-DD-site (où “YYYY-MM-DD-site” est
   l'identifiant pour votre atelier).
 - Créer le [site internet](https://github.com/datacarpentry/workshop-template)
   pour votre atelier
-- Aider l'hôte⋅sse à recruter des assistant⋅e⋅s pour l'atelier (au moins 1 assistant⋅e
+- Aider l'hôte⋅esse à recruter des assistant⋅e⋅s pour l'atelier (au moins 1 assistant⋅e
   pour 12 participant⋅e⋅s)
-- S'assurer en coordination avec l'hôte⋅sse que l'atelier est accessible à tou⋅te⋅s
+- S'assurer en coordination avec l'hôte⋅esse que l'atelier est accessible à tou⋅te⋅s
 - Se préparer à enseigner le contenu pédagogique de l'atelier
 - Envoyer un email aux participant⋅e⋅s pour leur rappeler le lieu et les heures de
   l'atelier, ainsi que des logiciels et autres pré-requis qu'ils doivent
   installer avant de venir à l'atelier. Cet email doit aussi contenir le lien de
   l'enquête d'avant-atelier.
-- S'assurer avec l'hôte⋅sse que tout le matériel nécessaire pour l'atelier est
+- S'assurer avec l'hôte⋅esse que tout le matériel nécessaire pour l'atelier est
   disponible, en particulier les post-its.
 
 #### Pendant l'atelier
@@ -141,7 +141,7 @@ Le⋅a formateur⋅rice principal⋅e est aussi responsable de la préparation d
 
 #### Après l'atelier
 
-- Se coordonner avec l'hôte⋅sse pour envoyer au⋅à la coordinateur⋅rice de Data Carpentry les informations sur les participant⋅e⋅s à l'atelier.
+- Se coordonner avec l'hôte⋅esse pour envoyer au⋅à la coordinateur⋅rice de Data Carpentry les informations sur les participant⋅e⋅s à l'atelier.
 - Compléter les mêmes tâches d'après atelier que les formateur⋅rice⋅s
 
 ### Les Responsabilités de tous les formateur⋅rice⋅s


### PR DESCRIPTION
J'ai ajouté de l'écriture inclusive utilisant le point médian ⋅ pour que la lecture soit plus fluide à pas mal d'endroits.
Et j'ai corrigé quelques anglicismes et tournures de phrases.

J'ai aussi remplacé le terme de thésard (qui est péjoratif) par doctorant qui est le terme officiel.